### PR TITLE
Record: initial specs integration

### DIFF
--- a/map_engine_wasm/Cargo.toml
+++ b/map_engine_wasm/Cargo.toml
@@ -21,6 +21,8 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 js-sys = "0.3.65"
 map_engine_core = { path = "../map_engine_core" }
 
+specs = { version = "0.20.0", features = ["specs-derive"] }
+
 [dependencies.web-sys]
 version = "0.3.65"
 features = [

--- a/map_engine_wasm/Cargo.toml
+++ b/map_engine_wasm/Cargo.toml
@@ -21,7 +21,7 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 js-sys = "0.3.65"
 map_engine_core = { path = "../map_engine_core" }
 
-specs = { version = "0.20.0", features = ["specs-derive"] }
+specs = { version = "0.20.0", features = ["specs-derive", "parallel"] }
 
 [dependencies.web-sys]
 version = "0.3.65"

--- a/map_engine_wasm/src/lib.rs
+++ b/map_engine_wasm/src/lib.rs
@@ -22,4 +22,50 @@ pub fn start() {
         "Hello world!!!!!! {}",
         &map_engine_core::add(2, 3)
     ));
+
+   let mut world = World::new();
+    world.register::<Position>();
+    world.register::<Velocity>();
+
+    world.create_entity().with(Position { x: 4.0, y: 7.0 }).build();
+
+    let mut hello_world = HelloWorld;
+    hello_world.run_now(&world);
+    world.maintain();    
+}
+
+use specs::{Builder, Component, ReadStorage, System, VecStorage, World, WorldExt, RunNow};
+
+#[derive(Debug)]
+struct Position {
+    x: f32,
+    y: f32,
+}
+
+impl Component for Position {
+    type Storage = VecStorage<Self>;
+}
+
+#[derive(Debug)]
+struct Velocity {
+    x: f32,
+    y: f32,
+}
+
+impl Component for Velocity {
+    type Storage = VecStorage<Self>;
+}
+
+struct HelloWorld;
+
+impl<'a> System<'a> for HelloWorld {
+    type SystemData = ReadStorage<'a, Position>;
+
+    fn run(&mut self, position: Self::SystemData) {
+        use specs::Join;
+
+        for position in position.join() {
+            log(&format!("Hello, {:?}", &position));
+        }
+    }
 }


### PR DESCRIPTION
Confirmed:

- specs runs in WASM (check the dev console)

    <img width="1345" alt="image" src="https://github.com/reearth/map-engine-prototype/assets/498788/6a23d3ed-8632-4c41-862e-3b41b6824b86">

- specs does not use WebWorker, even with "parallel" feature (check the "Source" tab in the dev console. "Worker" does not appear)